### PR TITLE
Migrate to Swift 6

### DIFF
--- a/.github/workflows/run_action.yml
+++ b/.github/workflows/run_action.yml
@@ -7,4 +7,7 @@ jobs:
     name: A job to run own action
     steps:
       - uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.0'
       - uses: BinaryBirds/swift-test-report@0.0.1

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -10,7 +10,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        
     ],
     targets: [
         .target(

--- a/Tests/testTests/testTests.swift
+++ b/Tests/testTests/testTests.swift
@@ -1,13 +1,15 @@
-import XCTest
+import Testing
 @testable import test
 
-final class testTests: XCTestCase {
-    
-    func testExample() throws {
-        XCTAssertEqual(test().text, "Hello, World!")
+@Suite("testTests")
+struct testTests {
+    @Test("example")
+    func testExample() {
+        #expect(test().text == "Hello, World!")
     }
-    
-    func testTest222Example() throws {
-        XCTAssertEqual(test().text, "1Hello, World!")
+
+    @Test("test222 example")
+    func testTest222Example() {
+        #expect(test().text == "1Hello, World!")
     }
 }


### PR DESCRIPTION
## Summary
- drop `swift-testing` package dependency
- update the tools version to Swift 6
- use Swift 6 toolchain in GitHub Actions

## Testing
- `swift test` *(fails: expectation in `test222 example` failed)*